### PR TITLE
Update chrome-ssb.sh

### DIFF
--- a/src/chrome-ssb.sh
+++ b/src/chrome-ssb.sh
@@ -89,6 +89,18 @@ EOF
 <string>com.google.Chrome.$name</string>
 <key>CFBundleShortVersionString</key>
 <string>1.0</string>
+<key>CFBundleURLTypes</key>
+<array>
+<dict>
+<key>CFBundleURLName</key>
+<string>Web site URL</string>
+<key>CFBundleURLSchemes</key>
+<array>
+<string>http</string>
+<string>https</string>
+</array>
+</dict>
+</array>
 </dict>
 </plist>
 EOF


### PR DESCRIPTION
added http and https url schemes to template so generated SSBs will be registered as browsers.